### PR TITLE
feat: simplify lint yml command

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,7 @@ module.exports = {
         "fluid",
         "plugin:yml/standard"
     ],
-    ignorePatterns: ["_site/", "src/_locales/messages.js", "!.*.cjs", "!.*.js"],
+    ignorePatterns: ["_site/", "src/_locales/messages.js", "!.*.cjs", "!.*.js", "!/.github"],
     env: {
         amd: true,
         browser: true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "lint:css": "stylelint \"**/*.css\"",
         "lint:js": "eslint \"**/*.js\"",
         "lint:markdown": "markdownlint-cli2 \"**/*.md\"",
-        "lint:yml": "eslint --no-error-on-unmatched-pattern \".github/**/*.yml\" \"**/*.yml\"",
+        "lint:yml": "eslint \"**/*.yml\"",
         "start": "npm-run-all -l clean -p start:*",
         "start:eleventy": "run-p dev cms",
         "prepare": "husky install"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

* [x] This pull request has been linted by running `npm run lint` without errors
* [x] This pull request has been tested by running `npm run start` and reviewing affected routes
* [x] This pull request has been built by running `npm run build` without errors
* [x] This isn't a duplicate of an existing pull request

## Description

Simplifies lint yml command by updating eslintrc ignore pattern.

## Steps to test

1. Change a yml file in .github directory, for example wrap value in dependabot.yml with quotation marks.
2. Run npm run lint:yml

**Expected behaviour:** <!-- What should happen -->

yml lint fails
